### PR TITLE
got ArgumentError when source includes non-ascii chars.

### DIFF
--- a/lib/linecache19.rb
+++ b/lib/linecache19.rb
@@ -333,6 +333,9 @@ module LineCache
             stat = nil
           end
           lines = SCRIPT_LINES__[name]
+          if "ruby19".respond_to?(:force_encoding)
+            lines.each{|l| l.force_encoding(Encoding.default_external) }
+          end
           @@file_cache[filename] = LineCacheInfo.new(stat, nil, lines, path, nil)
           @@file2file_remap[path] = filename
           return true


### PR DESCRIPTION
Hi, I'm using ruby-debug19 and linecache19 every day. I thank your work.

Recently, I got ArgumentError caused by Ruby 1.9 encoding mechanism when debugger tried to show my codes which includes non-ascii words(UTF-8 japanese word).

I made workaround for the problem. I would like you to merge mine into your work.

Thanks.
