### PR TITLE
Depend on require_relative

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -80,6 +80,8 @@ EOF
   spec.files = FILES.to_a  
   spec.extensions = ["ext/extconf.rb"]
 
+  spec.add_dependency "require_relative"
+
   spec.required_ruby_version = '>= 1.8.2'
   spec.date = Time.now
   spec.rubyforge_project = 'rocky-hacks'

--- a/Rakefile
+++ b/Rakefile
@@ -80,7 +80,7 @@ EOF
   spec.files = FILES.to_a  
   spec.extensions = ["ext/extconf.rb"]
 
-  spec.add_dependency "require_relative"
+  spec.add_dependency "require_relative", ">= 1.0.2"
 
   spec.required_ruby_version = '>= 1.8.2'
   spec.date = Time.now

--- a/linecache.gemspec
+++ b/linecache.gemspec
@@ -47,6 +47,7 @@ example in a debugger where the same lines are shown many times.
     ]
   s.extensions << "ext/trace_nums/extconf.rb"
   s.add_dependency("ruby_core_source", ">= 0.1.4")
+  s.add_dependency "require_relative"
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION

--- a/linecache.gemspec
+++ b/linecache.gemspec
@@ -47,7 +47,7 @@ example in a debugger where the same lines are shown many times.
     ]
   s.extensions << "ext/trace_nums/extconf.rb"
   s.add_dependency("ruby_core_source", ">= 0.1.4")
-  s.add_dependency "require_relative"
+  s.add_dependency "require_relative, ">= 1.0.2""
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION


### PR DESCRIPTION
For 1.8.7 compatibility.
require_relative will soon have no effect on 1.9, so it is a safe move.
